### PR TITLE
Add correct types to options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+0.1.3 (2020-09-04)
+------------------
+* Return correct type when serializing value
+
 0.1.2 (2020-03-01)
 ------------------
 * Allow options to be public or private

--- a/options/management/commands/setoption.py
+++ b/options/management/commands/setoption.py
@@ -24,6 +24,6 @@ class Command(BaseCommand):
             option, created = Option.objects.update_or_create(key=key, defaults={"value": value})
 
         YELLOW = "\033[33m"
-        verb = f"Created" if created else f"Updated"
+        verb = "Created" if created else "Updated"
         verb = f"{YELLOW}{verb}"
         self.stdout.write(f"{verb} option '{option}' with type '{option.value_type}'")

--- a/options/migrations/0004_option_public.py
+++ b/options/migrations/0004_option_public.py
@@ -11,6 +11,8 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.AddField(
-            model_name="option", name="public", field=models.BooleanField(default=True),
+            model_name="option",
+            name="public",
+            field=models.BooleanField(default=True),
         ),
     ]

--- a/options/models.py
+++ b/options/models.py
@@ -49,11 +49,22 @@ class Option(models.Model):
                 raise ValidationError("Type is bool but value is not bool")
         super().save(*args, **kwargs)
 
+    @property
+    def typed_value(self):
+        """
+        Return the value of this option with the correct type.
+        """
+        if self.value_type == TYPE_INT:
+            return self.as_int()
+        if self.value_type == TYPE_BOOL:
+            return self.as_bool()
+        return self.value
+
     def serialize(self):
         """
         Serialize an option as a dictionary
         """
-        return {self.key: self.value}
+        return {self.key: self.typed_value}
 
 
 def get_option(key):

--- a/options/models.py
+++ b/options/models.py
@@ -54,11 +54,18 @@ class Option(models.Model):
         """
         Return the value of this option with the correct type.
         """
-        if self.value_type == TYPE_INT:
+        if self.value_type == self.TYPE_INT:
             return self.as_int()
-        if self.value_type == TYPE_BOOL:
+        if self.value_type == self.TYPE_BOOL:
             return self.as_bool()
         return self.value
+
+    @typed_value.setter
+    def typed_value_setter(self, value):
+        """
+        Given a typed value, convert into string form and set the untyped variable.
+        """
+        self.value = str(value)
 
     def serialize(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"
 DESCRIPTION = open("README.md", encoding="utf-8").read()
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,10 +18,10 @@ class OptionListViewTestCase(TestCase):
         self.option3 = Option.objects.create(key=self.key3, value=self.value3, public=True)
 
         self.bool_option = Option.objects.create(
-            key="boolvalue", value="true", type=Option.TYPE_BOOL, public=True
+            key="boolvalue", value="true", value_type=Option.TYPE_BOOL, public=True
         )
         self.int_option = Option.objects.create(
-            key="intvalue", value="3", type=Option.TYPE_INT, public=True
+            key="intvalue", value="3", value_type=Option.TYPE_INT, public=True
         )
 
     def test_view(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,12 +17,18 @@ class OptionListViewTestCase(TestCase):
         self.option2 = Option.objects.create(key=self.key2, value=self.value2, public=True)
         self.option3 = Option.objects.create(key=self.key3, value=self.value3, public=True)
 
-        self.bool_option = Option.objects.create(key="boolvalue", value="true", public=True)
-        self.int_option = Option.objects.create(key="intvalue", value="3", public=True)
+        self.bool_option = Option.objects.create(
+            key="boolvalue", value="true", type=Option.TYPE_BOOL, public=True
+        )
+        self.int_option = Option.objects.create(
+            key="intvalue", value="3", type=Option.TYPE_INT, public=True
+        )
 
     def test_view(self):
         expected = self.option2.serialize()
         expected.update(self.option3.serialize())
+        expected.update(self.bool_option.serialize())
+        expected.update(self.int_option.serialize())
         response = self.client.get(reverse("options:option-list"))
         self.assertEqual(response.json(), expected)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,8 +17,18 @@ class OptionListViewTestCase(TestCase):
         self.option2 = Option.objects.create(key=self.key2, value=self.value2, public=True)
         self.option3 = Option.objects.create(key=self.key3, value=self.value3, public=True)
 
+        self.bool_option = Option.objects.create(key="boolvalue", value="true", public=True)
+        self.int_option = Option.objects.create(key="intvalue", value="3", public=True)
+
     def test_view(self):
         expected = self.option2.serialize()
         expected.update(self.option3.serialize())
         response = self.client.get(reverse("options:option-list"))
         self.assertEqual(response.json(), expected)
+
+    def test_view_typed(self):
+        resp = self.client.get(reverse("options:option-list"))
+        data = resp.json()
+
+        self.assertIsInstance(data["boolvalue"], bool)
+        self.assertIsInstance(data["intvalue"], int)

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
 skip_install = True
 commands = 
     flake8
-    isort -c
+    isort -c .
     black -l100 --check .
 deps = 
     black


### PR DESCRIPTION
- When returning options, serialize the to the correct types.
  - In the options endpoint, booleans and integers get properly converted to their JSON types.